### PR TITLE
Allow reverse setter if index is in autoRefresh and property is writable

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -85,7 +85,8 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('annotation_reader')->nullOnInvalid(), // @deprecated
                 service(EntityManagerInterface::class),
-                service('encryption.indexes_generator')
+                service('encryption.indexes_generator'),
+                service('property_accessor')
             ])
         ->alias(IndexableFieldsService::class, 'encryption.indexable_field')
 

--- a/src/Services/IndexableFieldsService.php
+++ b/src/Services/IndexableFieldsService.php
@@ -10,6 +10,7 @@ use Odandb\DoctrineCiphersweetEncryptionBundle\Exception\MissingPropertyFromRefl
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\ORM\EntityManagerInterface;
 use Odandb\DoctrineCiphersweetEncryptionBundle\Exception\UndefinedGeneratorException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class IndexableFieldsService
 {
@@ -19,12 +20,14 @@ class IndexableFieldsService
     private ?Reader $annReader;
     private EntityManagerInterface $em;
     private IndexesGenerator $indexesGenerator;
+    private PropertyAccessorInterface $propertyAccessor;
 
-    public function __construct(?Reader $annReader, EntityManagerInterface $em, IndexesGenerator $generator)
+    public function __construct(?Reader $annReader, EntityManagerInterface $em, IndexesGenerator $generator, PropertyAccessorInterface $propertyAccessor)
     {
         $this->annReader = $annReader;
         $this->em = $em;
         $this->indexesGenerator = $generator;
+        $this->propertyAccessor = $propertyAccessor;
     }
 
     /**
@@ -122,11 +125,11 @@ class IndexableFieldsService
      * @param null|array<int, string> $ids
      * @param array<int, array{refProperty: \ReflectionProperty, indexableConfig: IndexableField}> $fieldsContexts
      */
-    public function handleFilterableFieldsForChunck(string $className, ?array $ids, array $fieldsContexts, bool $needsToComputeChangeset = false): void
+    public function handleFilterableFieldsForChunck(string $className, ?array $ids, array $fieldsContexts, bool $runtimeMode = false): void
     {
         $chunck = $this->em->getRepository($className)->findBy(!empty($ids) ? ['id' => $ids] : []);
         foreach ($chunck as $entity) {
-            $this->handleIndexableFieldsForEntity($entity, $fieldsContexts, $needsToComputeChangeset);
+            $this->handleIndexableFieldsForEntity($entity, $fieldsContexts, $runtimeMode);
             $this->em->flush();
         }
     }
@@ -138,7 +141,7 @@ class IndexableFieldsService
      *
      * @throws UndefinedGeneratorException|\ReflectionException
      */
-    public function handleIndexableFieldsForEntity(object $entity, array $fieldsContexts, bool $needsToComputeChangeset = false): void
+    public function handleIndexableFieldsForEntity(object $entity, array $fieldsContexts, bool $runtimeMode = false): void
     {
         $className = get_class($entity);
         $searchIndexes = $this->generateIndexableValuesForEntity($entity, $fieldsContexts);
@@ -152,12 +155,11 @@ class IndexableFieldsService
 
             $indexes = $this->indexesGenerator->generateBlindIndexesFromPossibleValues($className, $refProperty->getName(), $indexesToEncrypt, $indexableAnnotationConfig->fastIndexing);
 
-            // We create the filter object instances and associate them to the parent entity
+            // We create the filter object instances and associate them to the parent entity if is needed
             $indexEntities = [];
             $indexEntityClass = $indexableAnnotationConfig->indexesEntityClass;
 
             $refClass = new \ReflectionClass($indexEntityClass);
-            $classMetadata = $this->em->getClassMetadata($refClass->getName());
             foreach ($indexes as $index) {
                 $indexEntity = $refClass->newInstance();
                 if ($indexEntity instanceof IndexedEntityInterface) {
@@ -167,10 +169,14 @@ class IndexableFieldsService
                     $indexEntities [] = $indexEntity;
 
                     $this->em->persist($indexEntity);
+                }
+            }
 
-                    if ($needsToComputeChangeset) {
-                        $this->em->getUnitOfWork()->computeChangeSet($classMetadata, $indexEntity);
-                    }
+            // If we are in runtime with autoRefresh indexes we set the inverse property. With the orphanRemoval option, this will delete the old collection.
+            // In other cases, the old indexes remain and must be purged by you.
+            if ($runtimeMode && $indexableAnnotationConfig->autoRefresh) {
+                if ($this->propertyAccessor->isWritable($entity, $refClass->getShortName())) {
+                    $this->propertyAccessor->setValue($entity, $refClass->getShortName(), $indexEntities);
                 }
             }
         }


### PR DESCRIPTION
On autoRefresh mode, we need to set the inserve property which must also have the orphanRemoval option set to true to delete old obsolete indexes