### PR TITLE
Allow reverse setter if index is in autoRefresh and property is writable

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -85,7 +85,8 @@ return static function (ContainerConfigurator $container): void {
             ->args([
                 service('annotation_reader')->nullOnInvalid(), // @deprecated
                 service(EntityManagerInterface::class),
-                service('encryption.indexes_generator')
+                service('encryption.indexes_generator'),
+                service('property_accessor')
             ])
         ->alias(IndexableFieldsService::class, 'encryption.indexable_field')
 


### PR DESCRIPTION
On autoRefresh mode, we need to set the inserve property which must also have the orphanRemoval option set to true to delete old obsolete indexes